### PR TITLE
fix: release workflow to use vars.* instead of env.*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,32 +58,32 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             docker pull ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ env.RELEASE_TAG }}
-            docker stop ${{ env.BACKEND_CONTAINER_NAME }} || true
-            docker rm ${{ env.BACKEND_CONTAINER_NAME }} || true
+            docker stop ${{ vars.BACKEND_CONTAINER_NAME }} || true
+            docker rm ${{ vars.BACKEND_CONTAINER_NAME }} || true
             docker run -d --restart=always \
-            --health-cmd="curl --fail localhost:${{ env.BACKEND_HTTP_SERVER_PORT }}/health" \
+            --health-cmd="curl --fail localhost:${{ vars.BACKEND_HTTP_SERVER_PORT }}/health" \
             --health-interval=10s \
             --health-timeout=5s \
             --health-retries=3 \
-            --name ${{ env.BACKEND_CONTAINER_NAME }} \
-            -p ${{ env.BACKEND_HTTP_SERVER_PORT }}:${{ env.BACKEND_HTTP_SERVER_PORT }} \
+            --name ${{ vars.BACKEND_CONTAINER_NAME }} \
+            -p ${{ vars.BACKEND_HTTP_SERVER_PORT }}:${{ vars.BACKEND_HTTP_SERVER_PORT }} \
             -e DATABASE_USER=${{ secrets.DATABASE_USER }} \
             -e DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }} \
             -e DATABASE_HOST=${{ secrets.DATABASE_HOST }} \
             -e DATABASE_PORT=${{ secrets.DATABASE_PORT }} \
             -e DATABASE_NAME=${{ secrets.DATABASE_NAME }} \
             -e SECRET_KEY=${{ secrets.SECRET_KEY }} \
-            -e LOG_LEVEL=${{ env.LOG_LEVEL }} \
-            -e SERVICE_NAME=${{ env.BACKEND_SERVICE_NAME }} \
+            -e LOG_LEVEL=${{ vars.LOG_LEVEL }} \
+            -e SERVICE_NAME=${{ vars.BACKEND_SERVICE_NAME }} \
             -e SERVICE_VERSION=${{ env.RELEASE_TAG }} \
-            -e HTTP_SERVER_PORT=${{ env.HTTP_SERVER_PORT }} \
-            -e TRACER_ENDPOINT=${{ env.TRACER_ENDPOINT }} \
-            -e TRACER_ENABLED=${{ env.TRACER_ENABLED }} \
-            -e KONG_URL=${{ env.KONG_URL }} \
+            -e HTTP_SERVER_PORT=${{ vars.HTTP_SERVER_PORT }} \
+            -e TRACER_ENDPOINT=${{ vars.TRACER_ENDPOINT }} \
+            -e TRACER_ENABLED=${{ vars.TRACER_ENABLED }} \
+            -e KONG_URL=${{ vars.KONG_URL }} \
             -e KONG_CONSUMER={{ secrets.KONG_CONSUMER }} \
             -e KONG_JWT_KEY={{ secrets.KONG_JWT_KEY }} \
-            --network=${{ env.DOCKER_NETWORK }} \
-             ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ env.RELEASE_TAG }} \
+            --network=${{ vars.DOCKER_NETWORK }} \
+             ${{ env.REGISTRY }}/${{ vars.BACKEND_IMAGE_NAME }}:${{ vars.RELEASE_TAG }} \
              http
 
   frontend-build-and-push-image:
@@ -132,11 +132,11 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             docker pull ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ env.RELEASE_TAG }}
-            docker stop ${{ env.FRONTEND_CONTAINER_NAME }} || true
-            docker rm ${{ env.FRONTEND_CONTAINER_NAME }} || true
+            docker stop ${{ vars.FRONTEND_CONTAINER_NAME }} || true
+            docker rm ${{ vars.FRONTEND_CONTAINER_NAME }} || true
             docker run -d \
-            --name ${{ env.FRONTEND_CONTAINER_NAME }} \
-            -p ${{ env.FRONTEND_HTTP_SERVER_PORT }}:80 \
-            -e VUE_APP_API_URL=${{ env.BACKEND_URL }} \
-            --network=${{ env.DOCKER_NETWORK }} \
+            --name ${{ vars.FRONTEND_CONTAINER_NAME }} \
+            -p ${{ vars.FRONTEND_HTTP_SERVER_PORT }}:80 \
+            -e VUE_APP_API_URL=${{ vars.BACKEND_URL }} \
+            --network=${{ vars.DOCKER_NETWORK }} \
              ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ env.RELEASE_TAG }}


### PR DESCRIPTION
# Description

> What was done in this PR?
Fix release workflow to use environment variables from `vars` instead of `env`

for more  details, see here: https://docs.github.com/pt/actions/learn-github-actions/contexts#vars-context